### PR TITLE
Update state_machines dependency versioning to >=

### DIFF
--- a/state_machines-activemodel.gemspec
+++ b/state_machines-activemodel.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^test\//)
   spec.require_paths = ['lib']
   spec.required_ruby_version     = '>= 1.9.3'
-  spec.add_dependency 'state_machines', '~> 0.2.0'
+  spec.add_dependency 'state_machines', '>= 0.3.0'
   spec.add_dependency 'activemodel', '~> 4.1'
 
   spec.add_development_dependency 'bundler', '>= 1.6'


### PR DESCRIPTION
This is breaking a pull request in `state_machines-activerecord` because it is too restrictive and 0.3.0 is out.