### PR TITLE
Trigger I18n reload after adding locale

### DIFF
--- a/lib/state_machines/integrations/active_model.rb
+++ b/lib/state_machines/integrations/active_model.rb
@@ -473,7 +473,10 @@ module StateMachines
 
       # Loads any locale files needed for translating validation errors
       def load_locale
-        I18n.load_path.unshift(locale_path) unless I18n.load_path.include?(locale_path)
+        unless I18n.load_path.include?(locale_path)
+          I18n.load_path.unshift(locale_path)
+          I18n.reload!
+        end
       end
 
       def locale_path


### PR DESCRIPTION
I was having issues like:
```ruby
Status translation missing: en.activerecord.errors.models.xxx.attributes.status.invalid_transition
```

After digging a bit, it appear `reload!` should be called after modifying the I18n load path.

@rafaelfranca for review please.
