### PR TITLE
Use ActiveSuport.on_load to set I18n load path

### DIFF
--- a/lib/state_machines-activemodel.rb
+++ b/lib/state_machines-activemodel.rb
@@ -1,1 +1,6 @@
+require 'active_support'
 require 'state_machines/integrations/active_model'
+
+ActiveSupport.on_load(:i18n) do
+  I18n.load_path << File.expand_path('state_machines/integrations/active_model/locale.rb', __dir__)
+end

--- a/lib/state_machines/integrations/active_model.rb
+++ b/lib/state_machines/integrations/active_model.rb
@@ -465,24 +465,6 @@ module StateMachines
         klass.lookup_ancestors
       end
 
-      # Initializes class-level extensions and defaults for this machine
-      def after_initialize
-        super()
-        load_locale
-      end
-
-      # Loads any locale files needed for translating validation errors
-      def load_locale
-        unless I18n.load_path.include?(locale_path)
-          I18n.load_path.unshift(locale_path)
-          I18n.reload!
-        end
-      end
-
-      def locale_path
-        "#{File.dirname(__FILE__)}/active_model/locale.rb"
-      end
-
       # Skips defining reader/writer methods since this is done automatically
       def define_state_accessor
         name = self.name

--- a/test/machine_with_internationalization_test.rb
+++ b/test/machine_with_internationalization_test.rb
@@ -144,28 +144,8 @@ class MachineWithInternationalizationTest < BaseTestCase
     assert_equal 'stop', machine.event(:park).human_name
   end
 
-  def test_should_only_add_locale_once_in_load_path
+  def test_should_have_locale_once_in_load_path
     assert_equal 1, I18n.load_path.select { |path| path =~ %r{active_model/locale\.rb$} }.length
-
-    # Create another ActiveModel model that will triger the i18n feature
-    new_model
-
-    assert_equal 1, I18n.load_path.select { |path| path =~ %r{active_model/locale\.rb$} }.length
-  end
-
-  def test_should_add_locale_to_beginning_of_load_path
-    @original_load_path = I18n.load_path
-    I18n.backend = I18n::Backend::Simple.new
-
-    app_locale = File.dirname(__FILE__) + '/files/en.yml'
-    default_locale = File.dirname(__FILE__) + '/../lib/state_machines/integrations/active_model/locale.rb'
-    I18n.load_path = [app_locale]
-
-    StateMachines::Machine.new(@model)
-
-    assert_equal [default_locale, app_locale].map { |path| File.expand_path(path) }, I18n.load_path.map { |path| File.expand_path(path) }
-  ensure
-    I18n.load_path = @original_load_path
   end
 
   def test_should_prefer_other_locales_first


### PR DESCRIPTION
Calling `I18n.reload!` causes the next call to `I18n` to load all the
locale data, which can be quite slow when there are a lot of
translations in your project. By setting the path when I18n loads, we
can avoid reloading invalidating the cache w/ `I18n.reload!`.

cc @rafaelfranca 