### PR TITLE
Remove the upperbound constraint on ActiveModel:

### DIFF
--- a/state_machines-activemodel.gemspec
+++ b/state_machines-activemodel.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version     = '>= 2.0.0'
   spec.add_dependency 'state_machines', '>= 0.5.0'
-  spec.add_dependency 'activemodel', '>= 4.1', '< 6.0'
+  spec.add_dependency 'activemodel', '>= 4.1'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake', '>= 10'


### PR DESCRIPTION
Remove the upperbound constraint on ActiveModel:

- During every ActiveSupport major bump, this gemspec needs to be
  updated.
  I think we are being too conservative and having an upperbound limit
  doesn't help.

  The proof is that each time there is a new Rails release, we just
  modify the gemspec without further modification ([here](https://github.com/state-machines/state_machines-activemodel/commit/eaa98f13808be9d8baaed346dd96c23c1b2958fc) and [here](https://github.com/state-machines/state_machines-activemodel/commit/43b740b07bc1dc27e34b6b2135e1ecce9fd70a90#diff-3bb7346aca79d8142e16e61372bd04dc))
  the gem

  The test suite already test ActiveModel on the edge https://github.com/state-machines/state_machines-activemodel/blob/f4a2a615a8bad2665f74041c3c7e544f1cbb4df8/Appraisals#L22-L24