### PR TITLE
Test on Ruby 2.7 and fix a keyword argument warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.4.6
   - 2.5.5
   - 2.6.3
+  - '2.7'
   - jruby
   - rbx-2
 
@@ -17,8 +18,6 @@ gemfile:
 matrix:
   include:
     - gemfile: gemfiles/active_model_4.1.gemfile
-      rvm: 2.1
-    - gemfile: gemfiles/active_model_4.1.gemfile
       rvm: 2.2.9
     - gemfile: gemfiles/active_model_4.1.gemfile
       rvm: 2.3.8
@@ -56,10 +55,17 @@ matrix:
       rvm: 2.5.5
     - gemfile: gemfiles/active_model_6.0.gemfile
       rvm: 2.6.3
+    - gemfile: gemfiles/active_model_6.0.gemfile
+      rvm: '2.7'
+    - gemfile: gemfiles/active_model_edge.gemfile
+      rvm: '2.7'
     - gemfile: gemfiles/active_model_edge.gemfile
       rvm: 2.6.3
     - gemfile: gemfiles/active_model_edge.gemfile
       rvm: 2.5.5
+  exclude:
+    gemfile: gemfiles/active_model_4.2.gemfile
+    rvm: '2.7'
   allow_failures:
     - rvm: jruby
     - rvm: rbx-2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.1
-  - 2.2.9
   - 2.3.8
   - 2.4.6
   - 2.5.5
@@ -18,11 +16,7 @@ gemfile:
 matrix:
   include:
     - gemfile: gemfiles/active_model_4.1.gemfile
-      rvm: 2.2.9
-    - gemfile: gemfiles/active_model_4.1.gemfile
       rvm: 2.3.8
-    - gemfile: gemfiles/active_model_5.0.gemfile
-      rvm: 2.2.9
     - gemfile: gemfiles/active_model_5.0.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/active_model_5.0.gemfile
@@ -32,8 +26,6 @@ matrix:
     - gemfile: gemfiles/active_model_5.0.gemfile
       rvm: 2.6.3
     - gemfile: gemfiles/active_model_5.1.gemfile
-      rvm: 2.2.9
-    - gemfile: gemfiles/active_model_5.1.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/active_model_5.1.gemfile
       rvm: 2.4.6
@@ -41,8 +33,6 @@ matrix:
       rvm: 2.5.5
     - gemfile: gemfiles/active_model_5.1.gemfile
       rvm: 2.6.3
-    - gemfile: gemfiles/active_model_5.2.gemfile
-      rvm: 2.2.9
     - gemfile: gemfiles/active_model_5.2.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/active_model_5.2.gemfile

--- a/lib/state_machines/integrations/active_model.rb
+++ b/lib/state_machines/integrations/active_model.rb
@@ -380,7 +380,7 @@ module StateMachines
           end
 
           default_options = default_error_message_options(object, attribute, message)
-          object.errors.add(attribute, message, options.merge(default_options))
+          object.errors.add(attribute, message, **options, **default_options)
         end
       end
 


### PR DESCRIPTION
Fix the following warning:

```
/tmp/bundle/ruby/2.7.0/gems/state_machines-activemodel-0.7.1/lib/state_machines/integrations/active_model.rb:383: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/tmp/bundle/ruby/2.7.0/bundler/gems/rails-9817d74f3be7/activemodel/lib/active_model/errors.rb:395: warning: The called method `add' is defined here
```

Note that `options.merge(default_options)` seem very weird to me. Without context I'd expect `options` to have precedence over `default_options`, but I opted for not changing the behavior.