### PR TITLE
account for aliased attributes when attribute methods are mixed in

### DIFF
--- a/lib/state_machines/integrations/active_model.rb
+++ b/lib/state_machines/integrations/active_model.rb
@@ -407,6 +407,10 @@ module StateMachines
       def define_state_initializer
         define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
           def initialize(params = {})
+            params = params.transform_keys do |key|
+              self.class.attribute_aliases[key.to_s] || key.to_s
+            end if self.class.respond_to?(:attribute_aliases)
+
             self.class.state_machines.initialize_states(self, {}, params) { super }
           end
         end_eval

--- a/lib/state_machines/integrations/active_model.rb
+++ b/lib/state_machines/integrations/active_model.rb
@@ -407,7 +407,7 @@ module StateMachines
       def define_state_initializer
         define_helper :instance, <<-end_eval, __FILE__, __LINE__ + 1
           def initialize(params = {})
-            params = params.transform_keys do |key|
+            params.transform_keys! do |key|
               self.class.attribute_aliases[key.to_s] || key.to_s
             end if self.class.respond_to?(:attribute_aliases)
 

--- a/test/machine_with_initialized_aliased_attribute_test.rb
+++ b/test/machine_with_initialized_aliased_attribute_test.rb
@@ -1,0 +1,33 @@
+require_relative 'test_helper'
+
+class MachineWithInitializedAliasedAttributeTest < BaseTestCase
+  def test_should_match_original_attribute_value_with_attribute_methods
+    model = new_model do
+      include ActiveModel::AttributeMethods
+      alias_attribute :custom_status, :state
+    end
+
+    machine = StateMachines::Machine.new(model, initial: :parked, integration: :active_model)
+    machine.other_states(:started)
+
+    record = model.new(custom_status: 'started')
+
+    refute record.state?(:parked)
+    assert record.state?(:started)
+  end
+
+  def test_should_not_original_attribute_value_without_attribute_methods
+    model = new_model do
+      alias_attribute :custom_status, :state
+    end
+
+    machine = StateMachines::Machine.new(model, initial: :parked, integration: :active_model)
+    machine.other_states(:started)
+
+    record = model.new(custom_status: 'started')
+
+    assert record.state?(:parked)
+    refute record.state?(:started)
+  end
+end
+

--- a/test/machine_with_initialized_aliased_attribute_test.rb
+++ b/test/machine_with_initialized_aliased_attribute_test.rb
@@ -16,7 +16,7 @@ class MachineWithInitializedAliasedAttributeTest < BaseTestCase
     assert record.state?(:started)
   end
 
-  def test_should_not_original_attribute_value_without_attribute_methods
+  def test_should_not_match_original_attribute_value_without_attribute_methods
     model = new_model do
       alias_attribute :custom_status, :state
     end


### PR DESCRIPTION
Fixes https://github.com/state-machines/state_machines-activemodel/issues/27

Moves `alias_attribute` fixes from https://github.com/state-machines/state_machines-activerecord/pull/95