### PR TITLE
drop unsupported version of rubies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,10 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', 'jruby', 'truffleruby']
+        ruby-version: ['2.7', '3.0', 'jruby', 'truffleruby']
         gemfiles:
-          - gemfiles/active_model_5.1.gemfile
-          - gemfiles/active_model_5.2.gemfile
           - gemfiles/active_model_6.0.gemfile
           - gemfiles/active_model_6.1.gemfile
           - gemfiles/active_model_7.0.gemfile
@@ -28,14 +26,10 @@ jobs:
             gemfiles: gemfiles/active_model_5.1.gemfile
           - ruby-version: 'truffleruby'
             gemfiles: gemfiles/active_model_5.2.gemfile
-          - ruby-version: '2.6'
-            gemfiles: gemfiles/active_model_7.0.gemfile
           - ruby-version: 'jruby'
             gemfiles: gemfiles/active_model_7.0.gemfile
           - ruby-version: 'truffleruby'
             gemfiles: gemfiles/active_model_7.0.gemfile
-          - ruby-version: '2.6'
-            gemfiles: gemfiles/active_model_edge.gemfile
           - ruby-version: 'jruby'
             gemfiles: gemfiles/active_model_edge.gemfile
           - ruby-version: 'truffleruby'

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in state_machine2_activemodel.gemspec
 gemspec
 
-platforms :mri_20, :mri_21 do
+platforms :mri do
   gem 'pry-byebug'
 end

--- a/state_machines-activemodel.gemspec
+++ b/state_machines-activemodel.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'state_machines/integrations/active_model/version'
+require_relative 'lib/state_machines/integrations/active_model/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'state_machines-activemodel'
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0")
   spec.test_files    = spec.files.grep(/^test\//)
   spec.require_paths = ['lib']
-  spec.required_ruby_version     = '>= 2.2.2'
+  spec.required_ruby_version     = '>= 2.6.8'
   spec.add_dependency 'state_machines', '>= 0.5.0'
   spec.add_dependency 'activemodel', '>= 5.1'
 

--- a/state_machines-activemodel.gemspec
+++ b/state_machines-activemodel.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version     = '>= 2.6.8'
   spec.add_dependency 'state_machines', '>= 0.5.0'
-  spec.add_dependency 'activemodel', '>= 5.1'
+  spec.add_dependency 'activemodel', '>= 6.0'
 
   spec.add_development_dependency 'bundler', '>= 1.6'
   spec.add_development_dependency 'rake', '>= 10'


### PR DESCRIPTION
Dropping support for ruby prior 2.7 so we can remove the[ kwarg warnings ](https://github.com/state-machines/state_machines/issues/82)and optimize the syntax.