### PR TITLE
resolve #34, prefer hard coded state human_name over default translation

### DIFF
--- a/lib/state_machines/integrations/active_model.rb
+++ b/lib/state_machines/integrations/active_model.rb
@@ -185,7 +185,7 @@ module StateMachines
     #
     # In order to hook in observer support for your application, the
     # ActiveModel::Observing feature must be included.  This can be added by including the
-    # https://github.com/state-machines/state_machines-activemodel-observers gem in your 
+    # https://github.com/state-machines/state_machines-activemodel-observers gem in your
     # Gemfile. Because of the way
     # ActiveModel observers are designed, there is less flexibility around the
     # specific transitions that can be hooked in.  However, a large number of
@@ -504,7 +504,7 @@ module StateMachines
       # Configures new states with the built-in humanize scheme
       def add_states(*)
         super.each do |new_state|
-          new_state.human_name = ->(state, klass) { translate(klass, :state, state.name) }
+          new_state.human_name ||= ->(state, klass) { translate(klass, :state, state.name) }
         end
       end
 


### PR DESCRIPTION
If the user hard codes a `human_name`, we should prefer it over the default translation method. 

```ruby
class MyClass
  state_machine :state, initial: :pending do
    state :pending, human_name: "To Do"
    state :in_progress, human_name: "In Progress"
  end
end
```